### PR TITLE
Fix typo in module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module asscii-render
+module ascii-render
 
 go 1.14


### PR DESCRIPTION
"assci-render" to "ascii-render" 

Probably would have left it alone if it was a rotating 🍑